### PR TITLE
docs: add default code of conduct and a readme

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming environment for
+all, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity,
+age, religion, nationality, or other such characteristics.
+
+Everyone is expected to follow the [Scala Code of
+Conduct](https://scala-lang.org/conduct/) when discussing the project on the
+available communication channels.
+
+## Moderation
+
+Any questions, concerns, or moderation requests please e-mail a moderator.
+
+| Organization admin                                  | Contact                   |
+| --------------------------------------------------- | ------------------------- |
+| 🇺🇸 [Chris Kipp](https://github.com/ckipp01)         | open-source@chris-kipp.io |
+| 🇮🇹 [Gabriele Petronella](https://github.com/gabro)  | gabriele@buildo.io        |
+| 🇮🇸 [Olafur Geirsson](https://github.com/olafurpg)   | scalameta@geirsson.com    |
+| 🇵🇱 [Tomasz Godzik](https://github.com/tgodzik)      | tgodzik@virtuslab.com     |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Scalameta .github
+
+This repo provides default [community health
+files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
+across the various [Scalameta Org](https://github.com/scalameta) repos. The
+[profile/](./profile/) is what will be displayed on the org GitHub page
+[here](https://github.com/scalameta). The other files at the root will be the
+defaults applied to any repositories within the org.


### PR DESCRIPTION
So the impetus behind this is that none (at least the ones I looked at) of our repos have any listed Code of Conduct. By defining it here, it will be then defaulted to in all the repos.